### PR TITLE
Fix murmurhash dependency and add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake build-essential
+
+    - name: configure CMake
+      run: cmake -B ${{github.workspace}}/build
+
+    - name: build
+      run: cmake --build ${{github.workspace}}/build
+
+    - name: test
+      working-directory: ${{github.workspace}}/build
+      run: ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,12 @@
 enable_testing()
 cmake_minimum_required(VERSION 3.10)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 project(Seva)
 
 set(CMAKE_C_STANDARD 11)
 
-set(MURMURHASH_INCLUDE_DIR lib/murmurhash)
-set(MURMURHASH_SOURCES lib/murmurhash/murmurhash.c)
+set(MURMURHASH_INCLUDE_DIR vendor/murmurhash)
+set(MURMURHASH_SOURCES vendor/murmurhash.c)
 
 set(APP_SOURCES
     src/htable.c
@@ -24,14 +25,4 @@ foreach(TEST_FILE ${TEST_SOURCES})
     add_executable(${TEST_NAME} ${TEST_FILE} ${APP_SOURCES} ${MURMURHASH_SOURCES})
     target_include_directories(${TEST_NAME} PUBLIC ${MURMURHASH_INCLUDE_DIR})
     add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
-endforeach()
-
-set_target_properties(seva PROPERTIES
-    COMPILE_COMMANDS_JSON_DIR "${CMAKE_BINARY_DIR}"
-)
-
-foreach(TEST_NAME)
-    set_target_properties(${TEST_NAME} PROPERTIES
-        COMPILE_COMMANDS_JSON_DIR "${CMAKE_BINARY_DIR}"
-    )
 endforeach()

--- a/src/htable.c
+++ b/src/htable.c
@@ -3,7 +3,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <stdint.h>
-#include "../lib/murmurhash/murmurhash.h"
+#include "../vendor/murmurhash.h"
 #include "htable.h"
 #include <ctype.h>
 

--- a/vendor/murmurhash.c
+++ b/vendor/murmurhash.c
@@ -1,0 +1,92 @@
+/**
+ * `murmurhash.c' - murmurhash
+ *
+ * copyright (c) 2014-2025 joseph werle <joseph.werle@gmail.com>
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "murmurhash.h"
+
+#if MURMURHASH_WANTS_HTOLE32
+#define MURMURHASH_HAS_HTOLE32 1
+#ifndef htole32
+static uint32_t htole32 (uint32_t value) {
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  value = (
+    ((value & 0xFF000000) >> 24) |
+    ((value & 0x00FF0000) >> 8)  |
+    ((value & 0x0000FF00) << 8)  |
+    ((value & 0x000000FF) << 24)
+  );
+#endif
+  return value;
+}
+#endif
+#endif
+
+uint32_t murmurhash (const char *key, uint32_t len, uint32_t seed) {
+  uint32_t c1 = 0xcc9e2d51;
+  uint32_t c2 = 0x1b873593;
+  uint32_t r1 = 15;
+  uint32_t r2 = 13;
+  uint32_t m = 5;
+  uint32_t n = 0xe6546b64;
+  uint32_t h = 0;
+  uint32_t k = 0;
+  uint8_t *d = (uint8_t *) key; // 32 bit extract from `key'
+  const uint32_t *chunks = NULL;
+  const uint8_t *tail = NULL; // tail - last 8 bytes
+  int i = 0;
+  int l = len / 4; // chunk length
+
+  h = seed;
+
+  chunks = (const uint32_t *) (d + l * 4); // body
+  tail = (const uint8_t *) (d + l * 4); // last 8 byte chunk of `key'
+
+  // for each 4 byte chunk of `key'
+  for (i = -l; i != 0; ++i) {
+    // next 4 byte chunk of `key'
+  #if MURMURHASH_HAS_HTOLE32
+    k = htole32(chunks[i]);
+  #else
+    k = chunks[i];
+  #endif
+
+    // encode next 4 byte chunk of `key'
+    k *= c1;
+    k = (k << r1) | (k >> (32 - r1));
+    k *= c2;
+
+    // append to hash
+    h ^= k;
+    h = (h << r2) | (h >> (32 - r2));
+    h = h * m + n;
+  }
+
+  k = 0;
+
+  // remainder
+  switch (len & 3) { // `len % 4'
+    case 3: k ^= (tail[2] << 16);
+    case 2: k ^= (tail[1] << 8);
+
+    case 1:
+      k ^= tail[0];
+      k *= c1;
+      k = (k << r1) | (k >> (32 - r1));
+      k *= c2;
+      h ^= k;
+  }
+
+  h ^= len;
+
+  h ^= (h >> 16);
+  h *= 0x85ebca6b;
+  h ^= (h >> 13);
+  h *= 0xc2b2ae35;
+  h ^= (h >> 16);
+
+  return h;
+}

--- a/vendor/murmurhash.h
+++ b/vendor/murmurhash.h
@@ -1,0 +1,25 @@
+/**
+ * `murmurhash.h' - murmurhash
+ *
+ * copyright (c) 2014-2025 joseph werle <joseph.werle@gmail.com>
+ */
+#ifndef MURMURHASH_H
+#define MURMURHASH_H
+
+#include <stdint.h>
+
+#define MURMURHASH_VERSION "0.2.0"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  /**
+   * Returns a murmur hash of `key' based on `seed'
+   * using the MurmurHash3 algorithm
+   */
+
+  uint32_t murmurhash (const char*, uint32_t, uint32_t);
+#ifdef __cplusplus
+}
+#endif
+#endif


### PR DESCRIPTION
This PR:
- Fixes the murmurhash dependency by moving the .c and .h file to a newly created `vendor/` directory.
- Adds the use of GitHub CI for tests.